### PR TITLE
add more tests for posix rule parser

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *Build) void {
     });
     b.installArtifact(lib);
 
-    var main_tests = b.addTest(.{
+    const main_tests = b.addTest(.{
         .root_source_file = .{ .path = "tzif.zig" },
         .optimize = optimize,
     });

--- a/tzif.zig
+++ b/tzif.zig
@@ -829,6 +829,10 @@ fn parsePosixTZ_designation(string: []const u8, idx: *usize) ![]const u8 {
             (!quoted and !std.ascii.isAlphabetic(string[idx.*])))
         {
             const designation = string[start..idx.*];
+
+            // The designation must be at least one character long!
+            if (designation.len == 0) return error.InvalidFormat;
+
             if (quoted) idx.* += 1;
             return designation;
         }

--- a/tzif.zig
+++ b/tzif.zig
@@ -1521,7 +1521,7 @@ test "posix TZ string, leap year, Asia/Jerusalem" {
     try testing.expectEqual(stdoff, result.offset(1603580400).offset);
 }
 
-// FIXME : Buenos Aires has DST all year long, make sure that it never returns the STD offset
+// Buenos Aires has DST all year long, make sure that it never returns the STD offset
 test "posix TZ string, leap year, America/Argentina/Buenos_Aires" {
     // IANA identifier: America/Argentina/Buenos_Aires
     const result = try parsePosixTZ("WART4WARST,J1/0,J365/25");

--- a/tzif.zig
+++ b/tzif.zig
@@ -1359,15 +1359,12 @@ test "posix TZ string, regular year" {
     dstoff = -10800;
     try testing.expectEqualSlices(u8, "WART", result.std_designation);
     try testing.expectEqualSlices(u8, "WARST", result.dst_designation.?);
-    // // FIXME : this does not work yet
-    // try testing.expectEqual(stdoff, result.std_offset);
-    // try testing.expectEqual(dstoff, result.dst_offset);
-    // // transition std 2023-03-24T01:59:59-03:00 --> dst 2023-03-24T03:00:00-03:00
-    // try testing.expectEqual(stdoff, result.offset(1679633999).offset);
-    // try testing.expectEqual(dstoff, result.offset(1679637600).offset);
-    // // transition dst 2023-10-29T01:59:59-03:00 --> std 2023-10-29T01:00:00-03:00
-    // try testing.expectEqual(dstoff, result.offset(1698555599).offset);
-    // try testing.expectEqual(stdoff, result.offset(1698552000).offset);
+    // transition std 2023-03-24T01:59:59-03:00 --> dst 2023-03-24T03:00:00-03:00
+    try testing.expectEqual(stdoff, result.offset(1679633999).offset);
+    try testing.expectEqual(dstoff, result.offset(1679637600).offset);
+    // transition dst 2023-10-29T01:59:59-03:00 --> std 2023-10-29T01:00:00-03:00
+    try testing.expectEqual(dstoff, result.offset(1698555599).offset);
+    try testing.expectEqual(stdoff, result.offset(1698552000).offset);
 
     // IANA identifier: America/Nuuk
     result = try parsePosixTZ("WGT3WGST,M3.5.0/-2,M10.5.0/-1");

--- a/tzif.zig
+++ b/tzif.zig
@@ -1456,23 +1456,30 @@ test "posix TZ string, leap year, Asia/Jerusalem" {
     try testing.expectEqual(stdoff, result.offset(1603580400).offset);
 }
 
-// FIXME : Buenos Aires has DST all year long
+// FIXME : Buenos Aires has DST all year long, make sure that it never returns the STD offset
 test "posix TZ string, leap year, America/Argentina/Buenos_Aires" {
     if (true) return error.SkipZigTest;
     // IANA identifier: America/Argentina/Buenos_Aires
     const result = try parsePosixTZ("WART4WARST,J1/0,J365/25");
-    const stdoff: i32 = -10800;
-    const dstoff: i32 = -10800;
+    const stdoff: i32 = -4 * std.time.s_per_hour;
+    const dstoff: i32 = -3 * std.time.s_per_hour;
     try testing.expectEqualSlices(u8, "WART", result.std_designation);
     try testing.expectEqualSlices(u8, "WARST", result.dst_designation.?);
-    try testing.expectEqual(stdoff, result.std_offset); // FIXME : this does not work yet
-    try testing.expectEqual(dstoff, result.dst_offset); // FIXME : this does not work yet
+    _ = stdoff;
+
     // transition std 2020-03-27T01:59:59-03:00 --> dst 2020-03-27T03:00:00-03:00
-    try testing.expectEqual(stdoff, result.offset(1585285199).offset);
+    try testing.expectEqual(dstoff, result.offset(1585285199).offset);
     try testing.expectEqual(dstoff, result.offset(1585288800).offset);
     // transtion dst 2020-10-25T01:59:59-03:00 --> std 2020-10-25T01:00:00-03:00
     try testing.expectEqual(dstoff, result.offset(1603601999).offset);
-    try testing.expectEqual(stdoff, result.offset(1603598400).offset);
+    try testing.expectEqual(dstoff, result.offset(1603598400).offset);
+
+    // Make sure it returns dstoff at the start of the year
+    try testing.expectEqual(dstoff, result.offset(1577836800).offset); // 2020
+    try testing.expectEqual(dstoff, result.offset(1609459200).offset); // 2021
+
+    // Make sure it returns dstoff at the end of the year
+    try testing.expectEqual(dstoff, result.offset(1609459199).offset);
 }
 
 test "posix TZ string, leap year, America/Nuuk" {

--- a/tzif.zig
+++ b/tzif.zig
@@ -771,15 +771,24 @@ fn parsePosixTZ_rule(_string: []const u8) !PosixTZ.Rule {
         }
 
         string = string[0..start_of_time];
+
         break :parse_time time;
     } else 2 * std.time.s_per_hour;
 
     if (string[0] == 'J') {
-        const julian_day1 = try std.fmt.parseInt(u16, string[1..], 10);
+        const julian_day1 = std.fmt.parseInt(u16, string[1..], 10) catch |err| switch (err) {
+            error.InvalidCharacter => return error.InvalidFormat,
+            error.Overflow => return error.InvalidFormat,
+        };
+
         if (julian_day1 < 1 or julian_day1 > 365) return error.InvalidFormat;
         return PosixTZ.Rule{ .JulianDay = .{ .day = julian_day1, .time = time } };
     } else if (std.ascii.isDigit(string[0])) {
-        const julian_day0 = try std.fmt.parseInt(u16, string[0..], 10);
+        const julian_day0 = std.fmt.parseInt(u16, string[0..], 10) catch |err| switch (err) {
+            error.InvalidCharacter => return error.InvalidFormat,
+            error.Overflow => return error.InvalidFormat,
+        };
+
         if (julian_day0 > 365) return error.InvalidFormat;
         return PosixTZ.Rule{ .JulianDayZero = .{ .day = julian_day0, .time = time } };
     } else if (string[0] == 'M') {
@@ -788,9 +797,18 @@ fn parsePosixTZ_rule(_string: []const u8) !PosixTZ.Rule {
         const n_str = split_iter.next() orelse return error.InvalidFormat;
         const d_str = split_iter.next() orelse return error.InvalidFormat;
 
-        const m = try std.fmt.parseInt(u8, m_str, 10);
-        const n = try std.fmt.parseInt(u8, n_str, 10);
-        const d = try std.fmt.parseInt(u8, d_str, 10);
+        const m = std.fmt.parseInt(u8, m_str, 10) catch |err| switch (err) {
+            error.InvalidCharacter => return error.InvalidFormat,
+            error.Overflow => return error.InvalidFormat,
+        };
+        const n = std.fmt.parseInt(u8, n_str, 10) catch |err| switch (err) {
+            error.InvalidCharacter => return error.InvalidFormat,
+            error.Overflow => return error.InvalidFormat,
+        };
+        const d = std.fmt.parseInt(u8, d_str, 10) catch |err| switch (err) {
+            error.InvalidCharacter => return error.InvalidFormat,
+            error.Overflow => return error.InvalidFormat,
+        };
 
         if (m < 1 or m > 12) return error.InvalidFormat;
         if (n < 1 or n > 5) return error.InvalidFormat;

--- a/tzif.zig
+++ b/tzif.zig
@@ -846,7 +846,7 @@ pub fn parsePosixTZ(string: []const u8) !PosixTZ {
 
     result.std_designation = try parsePosixTZ_designation(string, &idx);
 
-    // multiply by -1 to get offset as seconds East of Greenwich was TZif specifies it:
+    // multiply by -1 to get offset as seconds East of Greenwich as TZif specifies it:
     result.std_offset = try hhmmss_offset_to_s(string[idx..], &idx) * -1;
     if (idx >= string.len) {
         return result;
@@ -856,7 +856,7 @@ pub fn parsePosixTZ(string: []const u8) !PosixTZ {
         result.dst_designation = try parsePosixTZ_designation(string, &idx);
 
         if (idx < string.len and string[idx] != ',') {
-            // multiply by -1 to get offset as seconds East of Greenwich was TZif specifies it:
+            // multiply by -1 to get offset as seconds East of Greenwich as TZif specifies it:
             result.dst_offset = try hhmmss_offset_to_s(string[idx..], &idx) * -1;
         } else {
             result.dst_offset = result.std_offset + std.time.s_per_hour;

--- a/tzif.zig
+++ b/tzif.zig
@@ -363,9 +363,9 @@ pub const PosixTZ = struct {
                 }
             } else {
                 if (utc >= end_dst and utc < start_dst) {
-                    return .{ .offset = this.dst_offset, .designation = dst_designation, .is_daylight_saving_time = true };
-                } else {
                     return .{ .offset = this.std_offset, .designation = this.std_designation, .is_daylight_saving_time = false };
+                } else {
+                    return .{ .offset = this.dst_offset, .designation = dst_designation, .is_daylight_saving_time = true };
                 }
             }
         } else {
@@ -1784,8 +1784,6 @@ test "posix TZ GMT0BST-1,M3.5.0/1:00,M10.5.0/2:00 from zoneinfo_test.py" {
 
 test "posix TZ AEST-10AEDT,M10.1.0/2,M4.1.0/3 from zoneinfo_test.py" {
     // Austrialian time zone - DST start is chronologically first
-    // FIXME : this does not work yet
-    if (true) return error.SkipZigTest;
     const result = try parsePosixTZ("AEST-10AEDT,M10.1.0/2,M4.1.0/3");
     try testing.expectEqual(@as(i32, 39600), result.offset(1554469200).offset); // 2019-04-06T00:00:00+11:00
     try testing.expectEqual(@as(i32, 39600), result.offset(1554562740).offset); // 2019-04-07T01:59:00+11:00
@@ -1803,12 +1801,12 @@ test "posix TZ AEST-10AEDT,M10.1.0/2,M4.1.0/3 from zoneinfo_test.py" {
 
 test "posix TZ IST-1GMT0,M10.5.0,M3.5.0/1 from zoneinfo_test.py" {
     // Irish time zone - negative DST
-    // FIXME : this does not work yet
-    if (true) return error.SkipZigTest;
     const result = try parsePosixTZ("IST-1GMT0,M10.5.0,M3.5.0/1");
     try testing.expectEqual(@as(i32, 0), result.offset(1553904000).offset); // 2019-03-30T00:00:00+00:00
     try testing.expectEqual(@as(i32, 0), result.offset(1553993940).offset); // 2019-03-31T00:59:00+00:00
+    try testing.expectEqual(true, result.offset(1553993940).is_daylight_saving_time); // 2019-03-31T00:59:00+00:00
     try testing.expectEqual(@as(i32, 3600), result.offset(1553994000).offset); // 2019-03-31T02:00:00+01:00
+    try testing.expectEqual(false, result.offset(1553994000).is_daylight_saving_time); // 2019-03-31T02:00:00+01:00
     try testing.expectEqual(@as(i32, 3600), result.offset(1572044400).offset); // 2019-10-26T00:00:00+01:00
     try testing.expectEqual(@as(i32, 3600), result.offset(1572134340).offset); // 2019-10-27T00:59:00+01:00
     try testing.expectEqual(@as(i32, 3600), result.offset(1572134400).offset); // 2019-10-27T01:00:00+01:00
@@ -1829,8 +1827,6 @@ test "posix TZ <+11>-11 from zoneinfo_test.py" {
 
 test "posix TZ <-04>4<-03>,M9.1.6/24,M4.1.6/24 from zoneinfo_test.py" {
     // Quoted STD and DST, transitions at 24:00
-    // FIXME : this does not work yet
-    if (true) return error.SkipZigTest;
     const result = try parsePosixTZ("<-04>4<-03>,M9.1.6/24,M4.1.6/24");
     try testing.expectEqual(@as(i32, -14400), result.offset(1588305600).offset); // 2020-05-01T00:00:00-04:00
     try testing.expectEqual(@as(i32, -10800), result.offset(1604199600).offset); // 2020-11-01T00:00:00-03:00

--- a/tzif.zig
+++ b/tzif.zig
@@ -1519,3 +1519,164 @@ test "posix TZ string, leap year, America/Nuuk" {
     try testing.expectEqual(dstoff, result.offset(1603587599).offset);
     try testing.expectEqual(stdoff, result.offset(1603587600).offset);
 }
+
+test "posix TZ, valid strings" {
+    // from CPython's zoneinfo tests;
+    // https://github.com/python/cpython/blob/main/Lib/test/test_zoneinfo/test_zoneinfo.py
+    const tzstrs = [_][]const u8{
+        // Extreme offset hour
+        "AAA24",
+        "AAA+24",
+        "AAA-24",
+        "AAA24BBB,J60/2,J300/2",
+        "AAA+24BBB,J60/2,J300/2",
+        "AAA-24BBB,J60/2,J300/2",
+        "AAA4BBB24,J60/2,J300/2",
+        "AAA4BBB+24,J60/2,J300/2",
+        "AAA4BBB-24,J60/2,J300/2",
+        // Extreme offset minutes
+        "AAA4:00BBB,J60/2,J300/2",
+        "AAA4:59BBB,J60/2,J300/2",
+        "AAA4BBB5:00,J60/2,J300/2",
+        "AAA4BBB5:59,J60/2,J300/2",
+        // Extreme offset seconds
+        "AAA4:00:00BBB,J60/2,J300/2",
+        "AAA4:00:59BBB,J60/2,J300/2",
+        "AAA4BBB5:00:00,J60/2,J300/2",
+        "AAA4BBB5:00:59,J60/2,J300/2",
+        // Extreme total offset
+        "AAA24:59:59BBB5,J60/2,J300/2",
+        "AAA-24:59:59BBB5,J60/2,J300/2",
+        "AAA4BBB24:59:59,J60/2,J300/2",
+        "AAA4BBB-24:59:59,J60/2,J300/2",
+        // Extreme months
+        "AAA4BBB,M12.1.1/2,M1.1.1/2",
+        "AAA4BBB,M1.1.1/2,M12.1.1/2",
+        // Extreme weeks
+        "AAA4BBB,M1.5.1/2,M1.1.1/2",
+        "AAA4BBB,M1.1.1/2,M1.5.1/2",
+        // Extreme weekday
+        "AAA4BBB,M1.1.6/2,M2.1.1/2",
+        "AAA4BBB,M1.1.1/2,M2.1.6/2",
+        // Extreme numeric offset
+        "AAA4BBB,0/2,20/2",
+        "AAA4BBB,0/2,0/14",
+        "AAA4BBB,20/2,365/2",
+        "AAA4BBB,365/2,365/14",
+        // Extreme julian offset
+        "AAA4BBB,J1/2,J20/2",
+        "AAA4BBB,J1/2,J1/14",
+        "AAA4BBB,J20/2,J365/2",
+        "AAA4BBB,J365/2,J365/14",
+        // Extreme transition hour
+        "AAA4BBB,J60/167,J300/2",
+        "AAA4BBB,J60/+167,J300/2",
+        "AAA4BBB,J60/-167,J300/2",
+        "AAA4BBB,J60/2,J300/167",
+        "AAA4BBB,J60/2,J300/+167",
+        "AAA4BBB,J60/2,J300/-167",
+        // Extreme transition minutes
+        "AAA4BBB,J60/2:00,J300/2",
+        "AAA4BBB,J60/2:59,J300/2",
+        "AAA4BBB,J60/2,J300/2:00",
+        "AAA4BBB,J60/2,J300/2:59",
+        // Extreme transition seconds
+        "AAA4BBB,J60/2:00:00,J300/2",
+        "AAA4BBB,J60/2:00:59,J300/2",
+        "AAA4BBB,J60/2,J300/2:00:00",
+        "AAA4BBB,J60/2,J300/2:00:59",
+        // Extreme total transition time
+        "AAA4BBB,J60/167:59:59,J300/2",
+        "AAA4BBB,J60/-167:59:59,J300/2",
+        "AAA4BBB,J60/2,J300/167:59:59",
+        "AAA4BBB,J60/2,J300/-167:59:59",
+    };
+    for (tzstrs) |valid_str| {
+        _ = try parsePosixTZ(valid_str);
+    }
+}
+
+test "posix TZ, invalid strings" {
+    // FIXME : this does not work yet
+    if (true) return error.SkipZigTest;
+    // from CPython's zoneinfo tests;
+    // https://github.com/python/cpython/blob/main/Lib/test/test_zoneinfo/test_zoneinfo.py
+    const invalid_tzstrs = [_][]const u8{
+        "PST8PDT", // DST but no transition specified
+        "+11", // Unquoted alphanumeric
+        "GMT,M3.2.0/2,M11.1.0/3", // Transition rule but no DST
+        "GMT0+11,M3.2.0/2,M11.1.0/3", // Unquoted alphanumeric in DST
+        "PST8PDT,M3.2.0/2", // Only one transition rule
+        // Invalid offset hours
+        "AAA168",
+        "AAA+168",
+        "AAA-168",
+        "AAA168BBB,J60/2,J300/2",
+        "AAA+168BBB,J60/2,J300/2",
+        "AAA-168BBB,J60/2,J300/2",
+        "AAA4BBB168,J60/2,J300/2",
+        "AAA4BBB+168,J60/2,J300/2",
+        "AAA4BBB-168,J60/2,J300/2",
+        // Invalid offset minutes
+        "AAA4:0BBB,J60/2,J300/2",
+        "AAA4:100BBB,J60/2,J300/2",
+        "AAA4BBB5:0,J60/2,J300/2",
+        "AAA4BBB5:100,J60/2,J300/2",
+        // Invalid offset seconds
+        "AAA4:00:0BBB,J60/2,J300/2",
+        "AAA4:00:100BBB,J60/2,J300/2",
+        "AAA4BBB5:00:0,J60/2,J300/2",
+        "AAA4BBB5:00:100,J60/2,J300/2",
+        // Completely invalid dates
+        "AAA4BBB,M1443339,M11.1.0/3",
+        "AAA4BBB,M3.2.0/2,0349309483959c",
+        "AAA4BBB,,J300/2",
+        "AAA4BBB,z,J300/2",
+        "AAA4BBB,J60/2,",
+        "AAA4BBB,J60/2,z",
+        // Invalid months
+        "AAA4BBB,M13.1.1/2,M1.1.1/2",
+        "AAA4BBB,M1.1.1/2,M13.1.1/2",
+        "AAA4BBB,M0.1.1/2,M1.1.1/2",
+        "AAA4BBB,M1.1.1/2,M0.1.1/2",
+        // Invalid weeks
+        "AAA4BBB,M1.6.1/2,M1.1.1/2",
+        "AAA4BBB,M1.1.1/2,M1.6.1/2",
+        // Invalid weekday
+        "AAA4BBB,M1.1.7/2,M2.1.1/2",
+        "AAA4BBB,M1.1.1/2,M2.1.7/2",
+        // Invalid numeric offset
+        "AAA4BBB,-1/2,20/2",
+        "AAA4BBB,1/2,-1/2",
+        "AAA4BBB,367,20/2",
+        "AAA4BBB,1/2,367/2",
+        // Invalid julian offset
+        "AAA4BBB,J0/2,J20/2",
+        "AAA4BBB,J20/2,J366/2",
+        // Invalid transition time
+        "AAA4BBB,J60/2/3,J300/2",
+        "AAA4BBB,J60/2,J300/2/3",
+        // Invalid transition hour
+        "AAA4BBB,J60/168,J300/2",
+        "AAA4BBB,J60/+168,J300/2",
+        "AAA4BBB,J60/-168,J300/2",
+        "AAA4BBB,J60/2,J300/168",
+        "AAA4BBB,J60/2,J300/+168",
+        "AAA4BBB,J60/2,J300/-168",
+        // Invalid transition minutes
+        "AAA4BBB,J60/2:0,J300/2",
+        "AAA4BBB,J60/2:100,J300/2",
+        "AAA4BBB,J60/2,J300/2:0",
+        "AAA4BBB,J60/2,J300/2:100",
+        // Invalid transition seconds
+        "AAA4BBB,J60/2:00:0,J300/2",
+        "AAA4BBB,J60/2:00:100,J300/2",
+        "AAA4BBB,J60/2,J300/2:00:0",
+        "AAA4BBB,J60/2,J300/2:00:100",
+    };
+    for (invalid_tzstrs) |invalid_str| {
+        _ = parsePosixTZ(invalid_str) catch |err| {
+            try testing.expect(err == error.InvalidFormat);
+        };
+    }
+}

--- a/tzif.zig
+++ b/tzif.zig
@@ -631,7 +631,7 @@ fn year_to_secs(year: i32) i64 {
         cycles_since_epoch;
 
     const SECONDS_PER_REGULAR_YEAR = 365 * std.time.s_per_day;
-    return years_since_epoch * SECONDS_PER_REGULAR_YEAR + number_of_leap_days_since_epoch * std.time.s_per_day;
+    return @as(i64, years_since_epoch) * SECONDS_PER_REGULAR_YEAR + number_of_leap_days_since_epoch * std.time.s_per_day;
 }
 
 test year_to_secs {
@@ -1835,8 +1835,6 @@ test "posix TZ <-04>4<-03>,M9.1.6/24,M4.1.6/24 from zoneinfo_test.py" {
 test "posix TZ EST5EDT,0/0,J365/25 from zoneinfo_test.py" {
     // Permanent daylight saving time is modeled with transitions at 0/0
     // and J365/25, as mentioned in RFC 8536 Section 3.3.1
-    // FIXME : this does not work yet ( integer overflow )
-    if (true) return error.SkipZigTest;
     const result = try parsePosixTZ("EST5EDT,0/0,J365/25");
     try testing.expectEqual(@as(i32, -14400), result.offset(1546315200).offset); // 2019-01-01T00:00:00-04:00
     try testing.expectEqual(@as(i32, -14400), result.offset(1559361600).offset); // 2019-06-01T00:00:00-04:00

--- a/tzif.zig
+++ b/tzif.zig
@@ -1120,22 +1120,278 @@ test "posix TZ string" {
     // 2021-11-07T02:00:00-06:00 (1st Sunday of the 11th month, MDT)
     try testing.expectEqual(stdoff, result.offset(1636272000).offset);
 
-    // e.g. Europe/Berlin; DST transition time at 2 am if DST off-->on, 3 am if DST on-->off
+    // IANA identifier: Europe/Berlin
     result = try parsePosixTZ("CET-1CEST,M3.5.0,M10.5.0/3");
     stdoff = 3600;
     dstoff = 7200;
-
     try testing.expectEqualSlices(u8, "CET", result.std_designation);
     try testing.expectEqual(stdoff, result.std_offset);
     try testing.expectEqualSlices(u8, "CEST", result.dst_designation.?);
     try testing.expectEqual(dstoff, result.dst_offset);
     try testing.expectEqual(PosixTZ.Rule{ .MonthNthWeekDay = .{ .month = 3, .n = 5, .day = 0, .time = 2 * std.time.s_per_hour } }, result.dst_range.?.start);
     try testing.expectEqual(PosixTZ.Rule{ .MonthNthWeekDay = .{ .month = 10, .n = 5, .day = 0, .time = 3 * std.time.s_per_hour } }, result.dst_range.?.end);
-
     // 2023-10-29T00:59:59Z, or 2023-10-29 01:59:59 CEST. Offset should still be CEST.
     try testing.expectEqual(dstoff, result.offset(1698541199).offset);
     // 2023-10-29T01:00:00Z, or 2023-10-29 03:00:00 CEST. Offset should now be CET.
     try testing.expectEqual(stdoff, result.offset(1698541200).offset);
 
-    // TODO : add more tests
+    // IANA identifier: America/New_York
+    result = try parsePosixTZ("EST5EDT,M3.2.0/02:00:00,M11.1.0");
+    stdoff = -18000;
+    dstoff = -14400;
+    try testing.expectEqualSlices(u8, "EST", result.std_designation);
+    try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "EDT", result.dst_designation.?);
+    try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // FIXME : this does not work yet
+    // // transition std 2020-03-08T01:59:59-05:00 --> dst 2020-03-08T03:00:00-04:00
+    // try testing.expectEqual(stdoff, result.offset(1583650799).offset);
+    // try testing.expectEqual(dstoff, result.offset(1583650800).offset);
+    // // transition dst 2020-11-01T01:59:59-04:00 --> std 2020-11-01T01:00:00-05:00
+    // try testing.expectEqual(dstoff, result.offset(1604210399).offset);
+    // try testing.expectEqual(stdoff, result.offset(1604210400).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-12T01:59:59-05:00 --> dst 2023-03-12T03:00:00-04:00
+    try testing.expectEqual(stdoff, result.offset(1678604399).offset);
+    try testing.expectEqual(dstoff, result.offset(1678604400).offset);
+    // transition dst 2023-11-05T01:59:59-04:00 --> std 2023-11-05T01:00:00-05:00
+    try testing.expectEqual(dstoff, result.offset(1699163999).offset);
+    try testing.expectEqual(stdoff, result.offset(1699164000).offset);
+
+    // IANA identifier: America/New_York
+    result = try parsePosixTZ("EST5EDT,M3.2.0/02:00:00,M11.1.0/02:00:00");
+    stdoff = -18000;
+    dstoff = -14400;
+    try testing.expectEqualSlices(u8, "EST", result.std_designation);
+    try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "EDT", result.dst_designation.?);
+    try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // FIXME : this does not work yet
+    // // transition std 2020-03-08T01:59:59-05:00 --> dst 2020-03-08T03:00:00-04:00
+    // try testing.expectEqual(stdoff, result.offset(1583650799).offset);
+    // try testing.expectEqual(dstoff, result.offset(1583650800).offset);
+    // // transtion dst 2020-11-01T01:59:59-04:00 --> std 2020-11-01T01:00:00-05:00
+    // try testing.expectEqual(dstoff, result.offset(1604210399).offset);
+    // try testing.expectEqual(stdoff, result.offset(1604210400).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-12T01:59:59-05:00 --> dst 2023-03-12T03:00:00-04:00
+    try testing.expectEqual(stdoff, result.offset(1678604399).offset);
+    try testing.expectEqual(dstoff, result.offset(1678604400).offset);
+    // transition dst 2023-11-05T01:59:59-04:00 --> std 2023-11-05T01:00:00-05:00
+    try testing.expectEqual(dstoff, result.offset(1699163999).offset);
+    try testing.expectEqual(stdoff, result.offset(1699164000).offset);
+
+    // IANA identifier: America/New_York
+    result = try parsePosixTZ("EST5EDT,M3.2.0,M11.1.0/02:00:00");
+    stdoff = -18000;
+    dstoff = -14400;
+    try testing.expectEqualSlices(u8, "EST", result.std_designation);
+    try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "EDT", result.dst_designation.?);
+    try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // FIXME : this does not work yet
+    // // transition std 2020-03-08T01:59:59-05:00 --> dst 2020-03-08T03:00:00-04:00
+    // try testing.expectEqual(stdoff, result.offset(1583650799).offset);
+    // try testing.expectEqual(dstoff, result.offset(1583650800).offset);
+    // // transtion dst 2020-11-01T01:59:59-04:00 --> std 2020-11-01T01:00:00-05:00
+    // try testing.expectEqual(dstoff, result.offset(1604210399).offset);
+    // try testing.expectEqual(stdoff, result.offset(1604210400).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-12T01:59:59-05:00 --> dst 2023-03-12T03:00:00-04:00
+    try testing.expectEqual(stdoff, result.offset(1678604399).offset);
+    try testing.expectEqual(dstoff, result.offset(1678604400).offset);
+    // transition dst 2023-11-05T01:59:59-04:00 --> std 2023-11-05T01:00:00-05:00
+    try testing.expectEqual(dstoff, result.offset(1699163999).offset);
+    try testing.expectEqual(stdoff, result.offset(1699164000).offset);
+
+    // IANA identifier: America/Chicago
+    result = try parsePosixTZ("CST6CDT,M3.2.0/2:00:00,M11.1.0/2:00:00");
+    stdoff = -21600;
+    dstoff = -18000;
+    try testing.expectEqualSlices(u8, "CST", result.std_designation);
+    try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "CDT", result.dst_designation.?);
+    try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // FIXME : this does not work yet
+    // // transition std 2020-03-08T01:59:59-06:00 --> dst 2020-03-08T03:00:00-05:00
+    // try testing.expectEqual(stdoff, result.offset(1583654399).offset);
+    // try testing.expectEqual(dstoff, result.offset(1583654400).offset);
+    // // transtion dst 2020-11-01T01:59:59-05:00 --> std 2020-11-01T01:00:00-06:00
+    // try testing.expectEqual(dstoff, result.offset(1604213999).offset);
+    // try testing.expectEqual(stdoff, result.offset(1604214000).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-12T01:59:59-06:00 --> dst 2023-03-12T03:00:00-05:00
+    try testing.expectEqual(stdoff, result.offset(1678607999).offset);
+    try testing.expectEqual(dstoff, result.offset(1678608000).offset);
+    // transition dst 2023-11-05T01:59:59-05:00 --> std 2023-11-05T01:00:00-06:00
+    try testing.expectEqual(dstoff, result.offset(1699167599).offset);
+    try testing.expectEqual(stdoff, result.offset(1699167600).offset);
+
+    // IANA identifier: America/Denver
+    result = try parsePosixTZ("MST7MDT,M3.2.0/2:00:00,M11.1.0/2:00:00");
+    stdoff = -25200;
+    dstoff = -21600;
+    try testing.expectEqualSlices(u8, "MST", result.std_designation);
+    try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "MDT", result.dst_designation.?);
+    try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // FIXME : this does not work yet
+    // // transition std 2020-03-08T01:59:59-07:00 --> dst 2020-03-08T03:00:00-06:00
+    // try testing.expectEqual(stdoff, result.offset(1583657999).offset);
+    // try testing.expectEqual(dstoff, result.offset(1583658000).offset);
+    // // transtion dst 2020-11-01T01:59:59-06:00 --> std 2020-11-01T01:00:00-07:00
+    // try testing.expectEqual(dstoff, result.offset(1604217599).offset);
+    // try testing.expectEqual(stdoff, result.offset(1604217600).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-12T01:59:59-07:00 --> dst 2023-03-12T03:00:00-06:00
+    try testing.expectEqual(stdoff, result.offset(1678611599).offset);
+    try testing.expectEqual(dstoff, result.offset(1678611600).offset);
+    // transition dst 2023-11-05T01:59:59-06:00 --> std 2023-11-05T01:00:00-07:00
+    try testing.expectEqual(dstoff, result.offset(1699171199).offset);
+    try testing.expectEqual(stdoff, result.offset(1699171200).offset);
+
+    // IANA identifier: America/Los_Angeles
+    result = try parsePosixTZ("PST8PDT,M3.2.0/2:00:00,M11.1.0/2:00:00");
+    stdoff = -28800;
+    dstoff = -25200;
+    try testing.expectEqualSlices(u8, "PST", result.std_designation);
+    try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "PDT", result.dst_designation.?);
+    try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // FIXME : this does not work yet
+    // // transition std 2020-03-08T01:59:59-08:00 --> dst 2020-03-08T03:00:00-07:00
+    // try testing.expectEqual(stdoff, result.offset(1583661599).offset);
+    // try testing.expectEqual(dstoff, result.offset(1583661600).offset);
+    // // transtion dst 2020-11-01T01:59:59-07:00 --> std 2020-11-01T01:00:00-08:00
+    // try testing.expectEqual(dstoff, result.offset(1604221199).offset);
+    // try testing.expectEqual(stdoff, result.offset(1604221200).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-12T01:59:59-08:00 --> dst 2023-03-12T03:00:00-07:00
+    try testing.expectEqual(stdoff, result.offset(1678615199).offset);
+    try testing.expectEqual(dstoff, result.offset(1678615200).offset);
+    // transition dst 2023-11-05T01:59:59-07:00 --> std 2023-11-05T01:00:00-08:00
+    try testing.expectEqual(dstoff, result.offset(1699174799).offset);
+    try testing.expectEqual(stdoff, result.offset(1699174800).offset);
+
+    // IANA identifier: America/Sitka
+    result = try parsePosixTZ("AKST9AKDT,M3.2.0,M11.1.0");
+    stdoff = -32400;
+    dstoff = -28800;
+    try testing.expectEqualSlices(u8, "AKST", result.std_designation);
+    try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "AKDT", result.dst_designation.?);
+    try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // FIXME : this does not work yet
+    // // transition std 2020-03-08T01:59:59-09:00 --> dst 2020-03-08T03:00:00-08:00
+    // try testing.expectEqual(stdoff, result.offset(1583665199).offset);
+    // try testing.expectEqual(dstoff, result.offset(1583665200).offset);
+    // // transtion dst 2020-11-01T01:59:59-08:00 --> std 2020-11-01T01:00:00-09:00
+    // try testing.expectEqual(dstoff, result.offset(1604224799).offset);
+    // try testing.expectEqual(stdoff, result.offset(1604224800).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-12T01:59:59-09:00 --> dst 2023-03-12T03:00:00-08:00
+    try testing.expectEqual(stdoff, result.offset(1678618799).offset);
+    try testing.expectEqual(dstoff, result.offset(1678618800).offset);
+    // transition dst 2023-11-05T01:59:59-08:00 --> std 2023-11-05T01:00:00-09:00
+    try testing.expectEqual(dstoff, result.offset(1699178399).offset);
+    try testing.expectEqual(stdoff, result.offset(1699178400).offset);
+
+    // IANA identifier: Asia/Jerusalem
+    result = try parsePosixTZ("IST-2IDT,M3.4.4/26,M10.5.0");
+    stdoff = 7200;
+    dstoff = 10800;
+    try testing.expectEqualSlices(u8, "IST", result.std_designation);
+    try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "IDT", result.dst_designation.?);
+    try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // FIXME : this does not work yet
+    // // transition std 2020-03-27T01:59:59+02:00 --> dst 2020-03-27T03:00:00+03:00
+    // try testing.expectEqual(stdoff, result.offset(1585267199).offset);
+    // try testing.expectEqual(dstoff, result.offset(1585267200).offset);
+    // // transtion dst 2020-10-25T01:59:59+03:00 --> std 2020-10-25T01:00:00+02:00
+    // try testing.expectEqual(dstoff, result.offset(1603580399).offset);
+    // try testing.expectEqual(stdoff, result.offset(1603580400).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-24T01:59:59+02:00 --> dst 2023-03-24T03:00:00+03:00
+    try testing.expectEqual(stdoff, result.offset(1679615999).offset);
+    try testing.expectEqual(dstoff, result.offset(1679616000).offset);
+    // transition dst 2023-10-29T01:59:59+03:00 --> std 2023-10-29T01:00:00+02:00
+    try testing.expectEqual(dstoff, result.offset(1698533999).offset);
+    try testing.expectEqual(stdoff, result.offset(1698534000).offset);
+
+    // IANA identifier: America/Argentina/Buenos_Aires
+    result = try parsePosixTZ("WART4WARST,J1/0,J365/25");
+    stdoff = -10800;
+    dstoff = -10800;
+    try testing.expectEqualSlices(u8, "WART", result.std_designation);
+    // // FIXME : this does not work yet
+    // try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "WARST", result.dst_designation.?);
+    // try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // transition std 2020-03-27T01:59:59-03:00 --> dst 2020-03-27T03:00:00-03:00
+    // try testing.expectEqual(stdoff, result.offset(1585285199).offset);
+    // try testing.expectEqual(dstoff, result.offset(1585288800).offset);
+    // // transtion dst 2020-10-25T01:59:59-03:00 --> std 2020-10-25T01:00:00-03:00
+    // try testing.expectEqual(dstoff, result.offset(1603601999).offset);
+    // try testing.expectEqual(stdoff, result.offset(1603598400).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-24T01:59:59-03:00 --> dst 2023-03-24T03:00:00-03:00
+    // try testing.expectEqual(stdoff, result.offset(1679633999).offset);
+    // try testing.expectEqual(dstoff, result.offset(1679637600).offset);
+    // // transition dst 2023-10-29T01:59:59-03:00 --> std 2023-10-29T01:00:00-03:00
+    // try testing.expectEqual(dstoff, result.offset(1698555599).offset);
+    // try testing.expectEqual(stdoff, result.offset(1698552000).offset);
+
+    // IANA identifier: America/Nuuk
+    result = try parsePosixTZ("WGT3WGST,M3.5.0/-2,M10.5.0/-1");
+    stdoff = -10800;
+    dstoff = -7200;
+    try testing.expectEqualSlices(u8, "WGT", result.std_designation);
+    try testing.expectEqual(stdoff, result.std_offset);
+    try testing.expectEqualSlices(u8, "WGST", result.dst_designation.?);
+    try testing.expectEqual(dstoff, result.dst_offset);
+    // // ---
+    // // 2020, leap year
+    // // FIXME : this does not work yet
+    // // transition std 2020-03-28T21:59:59-03:00 --> dst 2020-03-28T23:00:00-02:00
+    // try testing.expectEqual(stdoff, result.offset(1585443599).offset);
+    // try testing.expectEqual(dstoff, result.offset(1585443600).offset);
+    // // transtion dst 2020-10-24T22:59:59-02:00 --> std 2020-10-24T22:00:00-03:00
+    // try testing.expectEqual(dstoff, result.offset(1603587599).offset);
+    // try testing.expectEqual(stdoff, result.offset(1603587600).offset);
+    // // ---
+    // 2023, normal year
+    // transition std 2023-03-28T21:59:59-02:00 --> dst 2023-03-28T23:00:00-02:00
+    // try testing.expectEqual(stdoff, result.offset(1680047999).offset);
+    // try testing.expectEqual(dstoff, result.offset(1680051600).offset);
+    // // transition dst 2023-10-24T22:59:59-02:00 --> std 2023-10-24T22:00:00-02:00
+    // try testing.expectEqual(dstoff, result.offset(1698195599).offset);
+    // try testing.expectEqual(stdoff, result.offset(1698192000).offset);
 }

--- a/tzif.zig
+++ b/tzif.zig
@@ -592,9 +592,9 @@ const UNIX_EPOCH_CYCLES = UNIX_EPOCH_YEAR / 400;
 
 /// Takes in year number, returns the unix timestamp for the start of the year.
 fn year_to_secs(year: i32) i64 {
-    const number_of_four_year_periods = @divFloor(year, 4);
-    const centuries = @divFloor(year, 100);
-    const cycles = @divFloor(year, 400);
+    const number_of_four_year_periods = @divFloor(year - 1, 4);
+    const centuries = @divFloor(year - 1, 100);
+    const cycles = @divFloor(year - 1, 400);
 
     const years_since_epoch = year - UNIX_EPOCH_YEAR;
     const number_of_four_year_periods_since_epoch = number_of_four_year_periods - UNIX_EPOCH_NUMBER_OF_4_YEAR_PERIODS;

--- a/tzif.zig
+++ b/tzif.zig
@@ -1749,3 +1749,155 @@ test "posix TZ invalid transition seconds" {
     try std.testing.expectError(error.InvalidFormat, parsePosixTZ("AAA4BBB,J60/2,J300/2:00:0"));
     try std.testing.expectError(error.InvalidFormat, parsePosixTZ("AAA4BBB,J60/2,J300/2:00:100"));
 }
+
+test "posix TZ EST5EDT,M3.2.0/4:00,M11.1.0/3:00 from zoneinfo_test.py" {
+    // Transition to EDT on the 2nd Sunday in March at 4 AM, and
+    // transition back on the first Sunday in November at 3AM
+    const result = try parsePosixTZ("EST5EDT,M3.2.0/4:00,M11.1.0/3:00");
+    try testing.expectEqual(@as(i32, -18000), result.offset(1552107600).offset); // 2019-03-09T00:00:00-05:00
+    try testing.expectEqual(@as(i32, -18000), result.offset(1552208340).offset); // 2019-03-10T03:59:00-05:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1572667200).offset); // 2019-11-02T00:00:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1572760740).offset); // 2019-11-03T01:59:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1572760800).offset); // 2019-11-03T02:00:00-04:00
+    try testing.expectEqual(@as(i32, -18000), result.offset(1572764400).offset); // 2019-11-03T02:00:00-05:00
+    try testing.expectEqual(@as(i32, -18000), result.offset(1583657940).offset); // 2020-03-08T03:59:00-05:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1604210340).offset); // 2020-11-01T01:59:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1604210400).offset); // 2020-11-01T02:00:00-04:00
+    try testing.expectEqual(@as(i32, -18000), result.offset(1604214000).offset); // 2020-11-01T02:00:00-05:00
+}
+
+test "posix TZ GMT0BST-1,M3.5.0/1:00,M10.5.0/2:00 from zoneinfo_test.py" {
+    // Transition to BST happens on the last Sunday in March at 1 AM GMT
+    // and the transition back happens the last Sunday in October at 2AM BST
+    const result = try parsePosixTZ("GMT0BST-1,M3.5.0/1:00,M10.5.0/2:00");
+    try testing.expectEqual(@as(i32, 0), result.offset(1553904000).offset); // 2019-03-30T00:00:00+00:00
+    try testing.expectEqual(@as(i32, 0), result.offset(1553993940).offset); // 2019-03-31T00:59:00+00:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1553994000).offset); // 2019-03-31T02:00:00+01:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1572044400).offset); // 2019-10-26T00:00:00+01:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1572134340).offset); // 2019-10-27T00:59:00+01:00
+    try testing.expectEqual(@as(i32, 0), result.offset(1585443540).offset); // 2020-03-29T00:59:00+00:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1585443600).offset); // 2020-03-29T02:00:00+01:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1603583940).offset); // 2020-10-25T00:59:00+01:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1603584000).offset); // 2020-10-25T01:00:00+01:00
+    try testing.expectEqual(@as(i32, 0), result.offset(1603591200).offset); // 2020-10-25T02:00:00+00:00
+}
+
+test "posix TZ AEST-10AEDT,M10.1.0/2,M4.1.0/3 from zoneinfo_test.py" {
+    // Austrialian time zone - DST start is chronologically first
+    // FIXME : this does not work yet
+    if (true) return error.SkipZigTest;
+    const result = try parsePosixTZ("AEST-10AEDT,M10.1.0/2,M4.1.0/3");
+    try testing.expectEqual(@as(i32, 39600), result.offset(1554469200).offset); // 2019-04-06T00:00:00+11:00
+    try testing.expectEqual(@as(i32, 39600), result.offset(1554562740).offset); // 2019-04-07T01:59:00+11:00
+    try testing.expectEqual(@as(i32, 39600), result.offset(1554562740).offset); // 2019-04-07T01:59:00+11:00
+    try testing.expectEqual(@as(i32, 39600), result.offset(1554562800).offset); // 2019-04-07T02:00:00+11:00
+    try testing.expectEqual(@as(i32, 39600), result.offset(1554562860).offset); // 2019-04-07T02:01:00+11:00
+    try testing.expectEqual(@as(i32, 36000), result.offset(1554566400).offset); // 2019-04-07T02:00:00+10:00
+    try testing.expectEqual(@as(i32, 36000), result.offset(1554566460).offset); // 2019-04-07T02:01:00+10:00
+    try testing.expectEqual(@as(i32, 36000), result.offset(1554570000).offset); // 2019-04-07T03:00:00+10:00
+    try testing.expectEqual(@as(i32, 36000), result.offset(1554570000).offset); // 2019-04-07T03:00:00+10:00
+    try testing.expectEqual(@as(i32, 36000), result.offset(1570197600).offset); // 2019-10-05T00:00:00+10:00
+    try testing.expectEqual(@as(i32, 36000), result.offset(1570291140).offset); // 2019-10-06T01:59:00+10:00
+    try testing.expectEqual(@as(i32, 39600), result.offset(1570291200).offset); // 2019-10-06T03:00:00+11:00
+}
+
+test "posix TZ IST-1GMT0,M10.5.0,M3.5.0/1 from zoneinfo_test.py" {
+    // Irish time zone - negative DST
+    // FIXME : this does not work yet
+    if (true) return error.SkipZigTest;
+    const result = try parsePosixTZ("IST-1GMT0,M10.5.0,M3.5.0/1");
+    try testing.expectEqual(@as(i32, 0), result.offset(1553904000).offset); // 2019-03-30T00:00:00+00:00
+    try testing.expectEqual(@as(i32, 0), result.offset(1553993940).offset); // 2019-03-31T00:59:00+00:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1553994000).offset); // 2019-03-31T02:00:00+01:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1572044400).offset); // 2019-10-26T00:00:00+01:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1572134340).offset); // 2019-10-27T00:59:00+01:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1572134400).offset); // 2019-10-27T01:00:00+01:00
+    try testing.expectEqual(@as(i32, 0), result.offset(1572138000).offset); // 2019-10-27T01:00:00+00:00
+    try testing.expectEqual(@as(i32, 0), result.offset(1572141600).offset); // 2019-10-27T02:00:00+00:00
+    try testing.expectEqual(@as(i32, 0), result.offset(1585443540).offset); // 2020-03-29T00:59:00+00:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1585443600).offset); // 2020-03-29T02:00:00+01:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1603583940).offset); // 2020-10-25T00:59:00+01:00
+    try testing.expectEqual(@as(i32, 3600), result.offset(1603584000).offset); // 2020-10-25T01:00:00+01:00
+    try testing.expectEqual(@as(i32, 0), result.offset(1603591200).offset); // 2020-10-25T02:00:00+00:00
+}
+
+test "posix TZ <+11>-11 from zoneinfo_test.py" {
+    // Pacific/Kosrae: Fixed offset zone with a quoted numerical tzname
+    const result = try parsePosixTZ("<+11>-11");
+    try testing.expectEqual(@as(i32, 39600), result.offset(1577797200).offset); // 2020-01-01T00:00:00+11:00
+}
+
+test "posix TZ <-04>4<-03>,M9.1.6/24,M4.1.6/24 from zoneinfo_test.py" {
+    // Quoted STD and DST, transitions at 24:00
+    // FIXME : this does not work yet
+    if (true) return error.SkipZigTest;
+    const result = try parsePosixTZ("<-04>4<-03>,M9.1.6/24,M4.1.6/24");
+    try testing.expectEqual(@as(i32, -14400), result.offset(1588305600).offset); // 2020-05-01T00:00:00-04:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1604199600).offset); // 2020-11-01T00:00:00-03:00
+}
+
+test "posix TZ EST5EDT,0/0,J365/25 from zoneinfo_test.py" {
+    // Permanent daylight saving time is modeled with transitions at 0/0
+    // and J365/25, as mentioned in RFC 8536 Section 3.3.1
+    // FIXME : this does not work yet ( integer overflow )
+    if (true) return error.SkipZigTest;
+    const result = try parsePosixTZ("EST5EDT,0/0,J365/25");
+    try testing.expectEqual(@as(i32, -14400), result.offset(1546315200).offset); // 2019-01-01T00:00:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1559361600).offset); // 2019-06-01T00:00:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1577851199).offset); // 2019-12-31T23:59:59.999999-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1577851200).offset); // 2020-01-01T00:00:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1583035200).offset); // 2020-03-01T00:00:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1590984000).offset); // 2020-06-01T00:00:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(1609473599).offset); // 2020-12-31T23:59:59.999999-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(13569480000).offset); // 2400-01-01T00:00:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(13574664000).offset); // 2400-03-01T00:00:00-04:00
+    try testing.expectEqual(@as(i32, -14400), result.offset(13601102399).offset); // 2400-12-31T23:59:59.999999-04:00
+}
+
+test "posix TZ AAA3BBB,J60/12,J305/12 from zoneinfo_test.py" {
+    // Transitions on March 1st and November 1st of each year
+    const result = try parsePosixTZ("AAA3BBB,J60/12,J305/12");
+    try testing.expectEqual(@as(i32, -10800), result.offset(1546311600).offset); // 2019-01-01T00:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1551322800).offset); // 2019-02-28T00:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1551452340).offset); // 2019-03-01T11:59:00-03:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1551452400).offset); // 2019-03-01T13:00:00-02:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1572613140).offset); // 2019-11-01T10:59:00-02:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1572613200).offset); // 2019-11-01T11:00:00-02:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1572616800).offset); // 2019-11-01T11:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1572620400).offset); // 2019-11-01T12:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1577847599).offset); // 2019-12-31T23:59:59.999999-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1577847600).offset); // 2020-01-01T00:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1582945200).offset); // 2020-02-29T00:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1583074740).offset); // 2020-03-01T11:59:00-03:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1583074800).offset); // 2020-03-01T13:00:00-02:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1604235540).offset); // 2020-11-01T10:59:00-02:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1604235600).offset); // 2020-11-01T11:00:00-02:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1604239200).offset); // 2020-11-01T11:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1604242800).offset); // 2020-11-01T12:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1609469999).offset); // 2020-12-31T23:59:59.999999-03:00
+}
+
+test "posix TZ <-03>3<-02>,M3.5.0/-2,M10.5.0/-1 from zoneinfo_test.py" {
+    // Taken from America/Godthab, this rule has a transition on the
+    // Saturday before the last Sunday of March and October, at 22:00 and 23:00,
+    // respectively. This is encoded with negative start and end transition times.
+    const result = try parsePosixTZ("<-03>3<-02>,M3.5.0/-2,M10.5.0/-1");
+    try testing.expectEqual(@as(i32, -10800), result.offset(1585278000).offset); // 2020-03-27T00:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1585443599).offset); // 2020-03-28T21:59:59-03:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1585443600).offset); // 2020-03-28T23:00:00-02:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1603580400).offset); // 2020-10-24T21:00:00-02:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1603584000).offset); // 2020-10-24T22:00:00-02:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1603587600).offset); // 2020-10-24T22:00:00-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1603591200).offset); // 2020-10-24T23:00:00-03:00
+}
+
+test "posix TZ AAA3BBB,M3.2.0/01:30,M11.1.0/02:15:45 from zoneinfo_test.py" {
+    // Transition times with minutes and seconds
+    const result = try parsePosixTZ("AAA3BBB,M3.2.0/01:30,M11.1.0/02:15:45");
+    try testing.expectEqual(@as(i32, -10800), result.offset(1331438400).offset); // 2012-03-11T01:00:00-03:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1331440200).offset); // 2012-03-11T02:30:00-02:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1351998944).offset); // 2012-11-04T01:15:44.999999-02:00
+    try testing.expectEqual(@as(i32, -7200), result.offset(1351998945).offset); // 2012-11-04T01:15:45-02:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1352002545).offset); // 2012-11-04T01:15:45-03:00
+    try testing.expectEqual(@as(i32, -10800), result.offset(1352006145).offset); // 2012-11-04T02:15:45-03:00
+}

--- a/tzif.zig
+++ b/tzif.zig
@@ -1334,14 +1334,12 @@ test "posix TZ string, regular year" {
     try testing.expectEqual(stdoff, result.std_offset);
     try testing.expectEqualSlices(u8, "WGST", result.dst_designation.?);
     try testing.expectEqual(dstoff, result.dst_offset);
-    // // FIXME : this does not work yet
-    // 2023, normal year
-    // // transition std 2023-03-28T21:59:59-02:00 --> dst 2023-03-28T23:00:00-02:00
-    // try testing.expectEqual(stdoff, result.offset(1680047999).offset);
-    // try testing.expectEqual(dstoff, result.offset(1680051600).offset);
-    // // transition dst 2023-10-24T22:59:59-02:00 --> std 2023-10-24T22:00:00-02:00
-    // try testing.expectEqual(dstoff, result.offset(1698195599).offset);
-    // try testing.expectEqual(stdoff, result.offset(1698192000).offset);
+    // transition std 2021-03-27T21:59:59-03:00 --> dst 2021-03-27T23:00:00-02:00
+    try testing.expectEqual(stdoff, result.offset(1616893199).offset);
+    try testing.expectEqual(dstoff, result.offset(1616893200).offset);
+    // transition dst 2021-10-30T22:59:59-02:00 --> std 2021-10-30T22:00:00-03:00
+    try testing.expectEqual(dstoff, result.offset(1635641999).offset);
+    try testing.expectEqual(stdoff, result.offset(1635642000).offset);
 }
 
 test "posix TZ string, leap year, America/New_York, start transition time specified" {


### PR DESCRIPTION
Add some more tests for exemplary POSIX TZ string. Addresses #7.

- [x] fix `"WART4WARST,J1/0,J365/25"` - this should return DST all year
- [x] fix `"WGT3WGST,M3.5.0/-2,M10.5.0/-1"` - revise. America/Nuuk changed from -3:00/-2:00 (2022) to -2:00/-1:00 hours offset (2024), so there was only a transition to DST in 2023, but no transition back to std. See also https://github.com/eggert/tz/blob/8bca213b081ab4e2610d74b3e46306338b2a6809/europe#L1106
- [x] tests from Python's zoneinfo: valid and invalid strings
- [x] tests from Python's zoneinfo: transition times
- [x] make the tests pass

---

Examples taken from https://developer.ibm.com/articles/au-aix-posix/ and https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html

Test-code generated with a Python script,so this basically tests against Python's `zoneinfo` code, which uses my system's tz db (zoneinfo; basically IANA db https://github.com/eggert/tz)